### PR TITLE
Parsing lines with comma on the right of the colon

### DIFF
--- a/ndms2_client/client.py
+++ b/ndms2_client/client.py
@@ -127,10 +127,10 @@ def _parse_dict_lines(lines: List[str]) -> Dict[str, any]:
         comma_pos = line.index(',') if ',' in line else None
         key = line[:colon_pos].strip()
         value = line[(colon_pos + 1):].strip()
-        new_indent = comma_pos if comma_pos is not None else colon_pos
+        new_indent = comma_pos if comma_pos is not None and comma_pos < colon_pos else colon_pos
 
         # assuming line is like 'mac-access, id = Bridge0: ...'
-        if comma_pos is not None:
+        if comma_pos is not None and comma_pos < colon_pos:
             key = line[:comma_pos].strip()
 
             value = {key: value} if value != '' else {}

--- a/tests/test_parse_dict_lines.py
+++ b/tests/test_parse_dict_lines.py
@@ -13,7 +13,7 @@ def test_parse_dict_lines(dict_text):
     _parse_dict_lines(dict_text.split('\n'))
 
 
-@pytest.fixture(params=range(3))
+@pytest.fixture(params=range(4))
 def dict_text(request):
     data = ['''
 
@@ -312,6 +312,27 @@ def dict_text(request):
                  schedule: 
 
            mac-access, id = Bridge0: permit
+
+''', '''
+
+               id: WifiMaster0/AccessPoint0
+            index: 0
+             type: AccessPoint
+      description: Wi-Fi access point
+   interface-name: AccessPoint
+             link: up
+        connected: yes
+            state: up
+              mtu: 1500
+         tx-queue: 1000
+            group: Home
+
+           usedby: Bridge0
+
+              mac: 00:ff:00:00:00:00
+        auth-type: none
+             ssid: home
+       encryption: wpa2,wpa3
 
 ''']
     return data[request.param]


### PR DESCRIPTION
KeeneticOS 3.1
After enable wpa3, encryption value is 'wpa2,wpa3'.

Traceback:
```
  File "/usr/local/lib/python3.7/site-packages/ndms2_client/client.py", line 36, in get_devices
    devices = _merge_devices(devices, self.get_associated_devices())
  File "/usr/local/lib/python3.7/site-packages/ndms2_client/client.py", line 63, in get_associated_devices
    ap_info = _parse_dict_lines(self._connection.run_command(_INTERFACE_CMD % ap))
  File "/usr/local/lib/python3.7/site-packages/ndms2_client/client.py", line 140, in _parse_dict_lines
    sub_key, sub_value = [p.strip() for p in arg.split('=', 1)]
ValueError: not enough values to unpack (expected 2, got 1)
```
